### PR TITLE
Rename crate to "tester"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tester"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "A fork of Rust’s `test` crate that doesn’t require unstable language features."
@@ -8,7 +8,7 @@ repository = "https://github.com/messense/rustc-test"
 edition = "2018"
 
 [lib]
-name = "test"
+name = "tester"
 crate-type = ["dylib", "rlib"]
 
 [features]


### PR DESCRIPTION
Fixes #3

Without this clippy can't continue to use compiletest.